### PR TITLE
elf2x68k環境でビルドを通りやすく

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ VDP_DIR = $(SRC_DIR)/vdp
 MEMMAP_DIR = $(SRC_DIR)/memmap
 DISK_DIR = $(SRC_DIR)/disk
 PERIPHERAL_DIR = $(SRC_DIR)/peripheral
+ASMINC_DIR = $(SRC_DIR)/include
 BUILD_DIR = build
 EXE_DIR = exe
 
@@ -21,8 +22,10 @@ LDFLAGS = -lm -lbas -liocs -ldos
 #LD = m68k-xelf-ld.x
 #LD_OPTS = -L /Users/ohnaka/work/XEiJ/HFS/XGCC/LIB/
 
-ASFLAGS = -i $(SRC_DIR) -i $(VDP_DIR) -i $(MEMMAP_DIR) -i ${DISK_DIR} -i ${PERIPHERAL_DIR} -i /Users/ohnaka/work/XEiJ/HFS/XGCC/INCLUDE/ -w0
-ASFLAGS_DEBUG = -d -s DEBUG -i $(SRC_DIR) -i $(VDP_DIR) -i $(MEMMAP_DIR) -i ${DISK_DIR} -i ${PERIPHERAL_DIR} -i /Users/ohnaka/work/XEiJ/HFS/XGCC/INCLUDE/ -w0
+-include ~/.human68k.mk
+
+ASFLAGS = -i $(SRC_DIR) -i $(ASMINC_DIR) -i $(VDP_DIR) -i $(MEMMAP_DIR) -i ${DISK_DIR} -i ${PERIPHERAL_DIR} -w0
+ASFLAGS_DEBUG = -d -s DEBUG $(ASFLAGS)
 
 # オブジェクトファイルのリストを変数にまとめる
 OBJS = $(BUILD_DIR)/ms.o \

--- a/src/disk/ms_disk_media_dskformat.c
+++ b/src/disk/ms_disk_media_dskformat.c
@@ -3,8 +3,8 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <fcntl.h>
-#include <doslib.h>
 #include <unistd.h>
+#include <x68k/dos.h>
 #include "ms_disk.h"
 #include "ms_disk_media_dskformat.h"
 #include "../ms.h"

--- a/src/include/doscall.mac
+++ b/src/include/doscall.mac
@@ -1,0 +1,155 @@
+* -*-Fundamental-*-
+*
+* PROJECT C Library, X68000 PROGRAMMING INTERFACE DEFINITION
+* --------------------------------------------------------------------
+* This file is written by the Project C Library Group,  and completely
+* in public domain. You can freely use, copy, modify, and redistribute
+* the whole contents, without this notice.
+* --------------------------------------------------------------------
+* $Id: doscall.mac,v 1.5 1993/10/06 16:43:41 mura Exp $
+*
+
+		.nlist
+
+__EXIT		equ		$ff00
+__GETCHAR	equ		$ff01
+__PUTCHAR	equ		$ff02
+__COMINP	equ		$ff03
+__COMOUT	equ		$ff04
+__PRNOUT	equ		$ff05
+__INPOUT	equ		$ff06
+__INKEY		equ		$ff07
+__GETC		equ		$ff08
+__PRINT		equ		$ff09
+__GETS		equ		$ff0a
+__KEYSNS	equ		$ff0b
+__KFLUSH	equ		$ff0c
+__FFLUSH	equ		$ff0d
+__CHGDRV	equ		$ff0e
+__CHDRV		equ		$ff0e
+__DRVCTRL	equ		$ff0f
+__CONSNS	equ		$ff10
+__PRNSNS	equ		$ff11
+__CINSNS	equ		$ff12
+__COUTSNS	equ		$ff13
+__FATCHK	equ		$ff17
+__HENDSP	equ		$ff18
+__CURDRV	equ		$ff19
+__GETSS		equ		$ff1a
+__FGETC		equ		$ff1b
+__FGETS		equ		$ff1c
+__FPUTC		equ		$ff1d
+__FPUTS		equ		$ff1e
+__ALLCLOSE	equ		$ff1f
+__SUPER		equ		$ff20
+__FNCKEY	equ		$ff21
+__KNJCTRL	equ		$ff22
+__CONCTRL	equ		$ff23
+__KEYCTRL	equ		$ff24
+__INTVCS	equ		$ff25
+__PSPSET	equ		$ff26
+__GETTIM2	equ		$ff27
+__SETTIM2	equ		$ff28
+__NAMESTS	equ		$ff29
+__GETDATE	equ		$ff2a
+__SETDATE	equ		$ff2b
+__GETTIME	equ		$ff2c
+__SETTIME	equ		$ff2d
+__VERIFY	equ		$ff2e
+__DUP0		equ		$ff2f
+__VERNUM	equ		$ff30
+__KEEPPR	equ		$ff31
+__GETDPB	equ		$ff32
+__BREAKCK	equ		$ff33
+__DRVXCHG	equ		$ff34
+__INTVCG	equ		$ff35
+__DSKFRE	equ		$ff36
+__NAMECK	equ		$ff37
+__MKDIR		equ		$ff39
+__RMDIR		equ		$ff3a
+__CHDIR		equ		$ff3b
+__CREATE	equ		$ff3c
+__OPEN		equ		$ff3d
+__CLOSE		equ		$ff3e
+__READ		equ		$ff3f
+__WRITE		equ		$ff40
+__DELETE	equ		$ff41
+__SEEK		equ		$ff42
+__CHMOD		equ		$ff43
+__IOCTRL	equ		$ff44
+__DUP		equ		$ff45
+__DUP2		equ		$ff46
+__CURDIR	equ		$ff47
+__MALLOC	equ		$ff48
+__MFREE		equ		$ff49
+__SETBLOCK	equ		$ff4a
+__EXEC		equ		$ff4b
+__EXIT2		equ		$ff4c
+__WAIT		equ		$ff4d
+__FILES		equ		$ff4e
+__NFILES	equ		$ff4f
+
+.ifdef		__HUMAN_V2__
+
+__SETPDB	equ		$ff50
+__GETPDB	equ		$ff51
+__SETENV	equ		$ff52
+__GETENV	equ		$ff53
+__VERIFYG	equ		$ff54
+__COMMON	equ		$ff55
+__RENAME	equ		$ff56
+__FILEDATE	equ		$ff57
+__MALLOC2	equ		$ff58
+__MAKETMP	equ		$ff5a
+__NEWFILE	equ		$ff5b
+__LOCK		equ		$ff5c
+__ASSIGN	equ		$ff5f
+__GETFCB	equ		$ff7c
+__S_MALLOC	equ		$ff7d
+__S_MFREE	equ		$ff7e
+__S_PROCESS	equ		$ff7f
+
+.else
+
+__SETPDB	equ		$ff80
+__GETPDB	equ		$ff81
+__SETENV	equ		$ff82
+__GETENV	equ		$ff83
+__VERIFYG	equ		$ff84
+__COMMON	equ		$ff85
+__RENAME	equ		$ff86
+__FILEDATE	equ		$ff87
+__MALLOC2	equ		$ff88
+__MAKETMP	equ		$ff8a
+__NEWFILE	equ		$ff8b
+__LOCK		equ		$ff8c
+__ASSIGN	equ		$ff8f
+__GETFCB	equ		$ffac
+__S_MALLOC	equ		$ffad
+__S_MFREE	equ		$ffae
+__S_PROCESS	equ		$ffaf
+
+.endif
+
+__RETSHELL	equ		$fff0
+__CTLABORT	equ		$fff1
+__ERRABORT	equ		$fff2
+__DISKRED	equ		$fff3
+__DISKWRT	equ		$fff4
+__INDOSFLG	equ		$fff5
+__SUPER_JSR	equ		$fff6
+__MEMCPY	equ		$fff7
+__OPEN_PR	equ		$fff8
+__KILL_PR	equ		$fff9
+__GET_PR	equ		$fffa
+__SUSPEND_PR	equ		$fffb
+__SLEEP_PR	equ		$fffc
+__SEND_PR	equ		$fffd
+__TIME_PR	equ		$fffe
+__CHANGE_PR	equ		$ffff
+
+DOS		macro		callname
+		dc.w		callname
+		endm
+
+		.list

--- a/src/include/iocscall.mac
+++ b/src/include/iocscall.mac
@@ -1,0 +1,243 @@
+* -*-Fundamental-*-
+*
+* PROJECT C Library, X68000 PROGRAMMING INTERFACE DEFINITION
+* --------------------------------------------------------------------
+* This file is written by the Project C Library Group,  and completely
+* in public domain. You can freely use, copy, modify, and redistribute
+* the whole contents, without this notice.
+* --------------------------------------------------------------------
+* $Id: iocscall.mac,v 1.5 1993/10/06 16:44:09 mura Exp $
+*
+
+		.nlist
+
+__B_KEYINP	equ		$00
+__B_KEYSNS	equ		$01
+__B_SFTSNS	equ		$02
+__BITSNS	equ		$04
+__SKEYSET	equ		$05
+__TVCTRL	equ		$0c
+__LEDMOD	equ		$0d
+__TGUSEMD	equ		$0e
+__DEFCHR	equ		$0f
+__CRTMOD	equ		$10
+__CONTRAST	equ		$11
+__HSVTORGB	equ		$12
+__TPALET	equ		$13
+__TPALET2	equ		$14
+__TCOLOR	equ		$15
+__FNTADR	equ		$16
+__VRAMGET	equ		$17
+__VRAMPUT	equ		$18
+__FNTGET	equ		$19
+__TEXTGET	equ		$1a
+__TEXTPUT	equ		$1b
+__CLIPPUT	equ		$1c
+__SCROLL	equ		$1d
+__B_CURON	equ		$1e
+__B_CUROFF	equ		$1f
+__B_PUTC	equ		$20
+__B_PRINT	equ		$21
+__B_COLOR	equ		$22
+__B_LOCATE	equ		$23
+__B_DOWN_S	equ		$24
+__B_UP_S	equ		$25
+__B_UP		equ		$26
+__B_DOWN	equ		$27
+__B_RIGHT	equ		$28
+__B_LEFT	equ		$29
+__B_CLR_ST	equ		$2a
+__B_ERA_ST	equ		$2b
+__B_INS		equ		$2c
+__B_DEL		equ		$2d
+__B_CONSOL	equ		$2e
+__B_PUTMES	equ		$2f
+__SET232C	equ		$30
+__LOF232C	equ		$31
+__INP232C	equ		$32
+__ISNS232C	equ		$33
+__OSNS232C	equ		$34
+__OUT232C	equ		$35
+__JOYGET	equ		$3b
+__INIT_PRN	equ		$3c
+__SNSPRN	equ		$3d
+__OUTLPT	equ		$3e
+__OUTPRN	equ		$3f
+__B_SEEK	equ		$40
+__B_VERIFY	equ		$41
+__B_READDI	equ		$42
+__B_DSKINI	equ		$43
+__B_DRVSNS	equ		$44
+__B_WRITE	equ		$45
+__B_READ	equ		$46
+__B_RECALI	equ		$47
+__B_ASSIGN	equ		$48
+__B_WRITED	equ		$49
+__B_READID	equ		$4a
+__B_BADFMT	equ		$4b
+__B_READDL	equ		$4c
+__B_FORMAT	equ		$4d
+__B_DRVCHK	equ		$4e
+__B_EJECT	equ		$4f
+__DATEBCD	equ		$50
+__DATESET	equ		$51
+__TIMEBCD	equ		$52
+__TIMESET	equ		$53
+__DATEGET	equ		$54
+__DATEBIN	equ		$55
+__TIMEGET	equ		$56
+__TIMEBIN	equ		$57
+__DATECNV	equ		$58
+__TIMECNV	equ		$59
+__DATEASC	equ		$5a
+__TIMEASC	equ		$5b
+__DAYASC	equ		$5c
+__ALARMMOD	equ		$5d
+__ALARMSET	equ		$5e
+__ALARMGET	equ		$5f
+__ADPCMOUT	equ		$60
+__ADPCMINP	equ		$61
+__ADPCMAOT	equ		$62
+__ADPCMAIN	equ		$63
+__ADPCMLOT	equ		$64
+__ADPCMLIN	equ		$65
+__ADPCMSNS	equ		$66
+__ADPCMMOD	equ		$67
+__OPMSET	equ		$68
+__OPMSNS	equ		$69
+__OPMINTST	equ		$6a
+__TIMERDST	equ		$6b
+__VDISPST	equ		$6c
+__CRTCRAS	equ		$6d
+__HSYNCST	equ		$6e
+__PRNINTST	equ		$6f
+__MS_INIT	equ		$70
+__MS_CURON	equ		$71
+__MS_CUROF	equ		$72
+__MS_STAT	equ		$73
+__MS_GETDT	equ		$74
+__MS_CURGT	equ		$75
+__MS_CURST	equ		$76
+__MS_LIMIT	equ		$77
+__MS_OFFTM	equ		$78
+__MS_ONTM	equ		$79
+__MS_PATST	equ		$7a
+__MS_SEL	equ		$7b
+__MS_SEL2	equ		$7c
+__SKEY_MOD	equ		$7d
+__DENSNS	equ		$7e
+__ONTIME	equ		$7f
+__B_INTVCS	equ		$80
+__B_SUPER	equ		$81
+__B_BPEEK	equ		$82
+__B_WPEEK	equ		$83
+__B_LPEEK	equ		$84
+__B_MEMSTR	equ		$85
+__B_BPOKE	equ		$86
+__B_WPOKE	equ		$87
+__B_LPOKE	equ		$88
+__B_MEMSET	equ		$89
+__DMAMOVE	equ		$8a
+__DMAMOV_A	equ		$8b
+__DMAMOV_L	equ		$8c
+__DMAMODE	equ		$8d
+__BOOTINF	equ		$8e
+__ROMVER	equ		$8f
+__G_CLR_ON	equ		$90
+__GPALET	equ		$94
+__SFTJIS	equ		$a0
+__JISSFT	equ		$a1
+__AKCONV	equ		$a2
+__RMACNV	equ		$a3
+__DAKJOB	equ		$a4
+__HANJOB	equ		$a5
+__B_CONMOD	equ		$ad	* enhanced by iocs.x
+__OS_CURON	equ		$ae
+__OS_CUROF	equ		$af
+__DRAWMODE	equ		$b0	* enhanced by iocs.x
+__APAGE		equ		$b1
+__VPAGE		equ		$b2
+__HOME		equ		$b3
+__WINDOW	equ		$b4
+__WIPE		equ		$b5
+__PSET		equ		$b6
+__POINT		equ		$b7
+__LINE		equ		$b8
+__BOX		equ		$b9
+__FILL		equ		$ba
+__CIRCLE	equ		$bb
+__PAINT		equ		$bc
+__SYMBOL	equ		$bd
+__GETGRM	equ		$be
+__PUTGRM	equ		$bf
+__SP_INIT	equ		$c0
+__SP_ON		equ		$c1
+__SP_OFF	equ		$c2
+__SP_CGCLR	equ		$c3
+__SP_DEFCG	equ		$c4
+__SP_GTPCG	equ		$c5
+__SP_REGST	equ		$c6
+__SP_REGGT	equ		$c7
+__BGSCRLST	equ		$c8
+__BGSCRLGT	equ		$c9
+__BGCTRLST	equ		$ca
+__BGCTRLGT	equ		$cb
+__BGTEXTCL	equ		$cc
+__BGTEXTST	equ		$cd
+__BGTEXTGT	equ		$ce
+__SPALET	equ		$cf
+__TXXLINE	equ		$d3
+__TXYLINE	equ		$d4
+__TXLINE	equ		$d5	* enhanced by iocs.x
+__TXBOX		equ		$d6
+__TXFILL	equ		$d7
+__TXREV		equ		$d8
+__TXRASCPY	equ		$df
+__OPMDRV	equ		$f0	* enhanced by opmdrv.sys
+__RSDRV		equ		$f1	* enhanced by rsdrv.sys
+__A_JOY		equ		$f2	* enhanced by ajoy.x
+__ABORTRST	equ		$fd
+__IPLERR	equ		$fe
+__ABORTJOB	equ		$ff
+
+__S_RESET	equ		$00
+__S_SELECT	equ		$01
+__S_CMDOUT	equ		$03
+__S_DATAIN	equ		$04
+__S_DATAOUT	equ		$05
+__S_STSIN	equ		$06
+__S_MSGIN	equ		$07
+__S_MSGOUT	equ		$08
+__S_PHASE	equ		$09
+__S_DATAIN_P	equ		$0B	* undefined
+__S_DATAOUT_P	equ		$0C	* undefined
+__S_INQUIRY	equ		$20
+__S_READ	equ		$21
+__S_WRITE	equ		$22
+__S_FORMAT	equ		$23
+__S_TESTUNIT	equ		$24
+__S_READCAP	equ		$25
+__S_READEXT	equ		$26
+__S_WRITEEXT	equ		$27
+__S_VERIFY	equ		$28	* undefined
+__S_MODESENSE	equ		$29	* undefined
+__S_MODESELECT	equ		$2A	* undefined
+__S_REZEROUNIT	equ		$2B
+__S_REQUEST	equ		$2C
+__S_SEEK	equ		$2D
+__S_STARTSTOP	equ		$2F
+__S_REASSIGN	equ		$31
+__S_PAMEDIUM	equ		$32
+
+SCSI		macro		func
+		moveq.l		#$f5,d0
+		moveq.l		#func,d1
+		trap		#15
+		endm
+
+IOCS		macro		number
+		moveq.l		#number,d0
+		trap		#15
+		endm
+
+		.list

--- a/src/ms.c
+++ b/src/ms.c
@@ -15,9 +15,9 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <ctype.h>
-#include <iocslib.h>
-#include <doslib.h>
 #include <getopt.h>
+#include <x68k/iocs.h>
+#include <x68k/dos.h>
 #include "ms.h"
 #include "ms_R800.h"
 #include "ms_iomap.h"

--- a/src/peripheral/ms_peripherals.has
+++ b/src/peripheral/ms_peripherals.has
@@ -6,8 +6,8 @@
 *				1995.9.15		by Kuni.
 *
 
-	.include	iocscall.equ
-*	.include	doscall.equ
+	.include	iocscall.mac
+*	.include	doscall.mac
 
 	.xdef	r_port_90
 	.xdef	r_port_A9

--- a/src/peripheral/ms_psg_mac.has
+++ b/src/peripheral/ms_psg_mac.has
@@ -6,8 +6,8 @@
 *				1995.10.19		by Kuni.
 *
 
-	.include	iocscall.equ
-	.include	doscall.equ
+	.include	iocscall.mac
+	.include	doscall.mac
 
 
 	.xref	_ms_peripherals_led_kana
@@ -195,22 +195,22 @@ ms_psg_init_mac:
 
 *	割り込みの設定
 	lea.l	OPM_int,a1
-	IOCS	_OPMINTST
+	IOCS	__OPMINTST
 	tst.l	d0
 	beq	@f
 
 	pea.l	errms_OPM_int			* 既に使用中のとき
-	DOS	_PRINT
+	DOS	__PRINT
 	lea.l	4(sp),sp
 	move.w	sr,d0
 	move.w	d0,-(sp)
 	or.w	#%00000111_00000000,d0		* 割り込み禁止
 	move.w	d0,sr
 	clr.l	a1
-	IOCS	_OPMINTST
+	IOCS	__OPMINTST
 	move.w	(sp)+,sr			* 割り込み復帰
 	lea.l	OPM_int,a1
-	IOCS	_OPMINTST
+	IOCS	__OPMINTST
 
 @@:	w_OPM	#$dc,#$10			* CLKA = 881
 	w_OPM	#$01,#$11			* 143*16μｓごとに割り込み
@@ -235,7 +235,7 @@ ms_psg_deinit_mac:
 	or.w	#%00000111_00000000,d0	* 一時的に割り込み禁止
 	move.w	d0,sr
 	clr.l	a1			* OPM割り込みを禁止
-	IOCS	_OPMINTST
+	IOCS	__OPMINTST
 	move.w	(sp)+,sr		* sr を復元
 
 *	すべてキーオフ
@@ -680,7 +680,7 @@ w_PSG_R13:
 
 w_PSG_R14:
 	pea.l	errms_PSG_R14_wr
-	DOS	_PRINT
+	DOS	__PRINT
 	lea.l	4(sp),sp
 	rts
 


### PR DESCRIPTION
elf2x68k環境でビルドを通しやすいように若干の修正を加えました。

run68やHAS060.Xのパスが違う場合は、ホームディレクトリに`.human68k.mk`というファイルを作ることで変数を上書きします。  
内容例:
```
AS = ~/bin/run68 ~/bin/has060.x
```
