### PR TITLE
68000での起動時のエラー処理を修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ASFLAGS = -i $(SRC_DIR) -i $(ASMINC_DIR) -i $(VDP_DIR) -i $(MEMMAP_DIR) -i ${DIS
 ASFLAGS_DEBUG = -d -s DEBUG $(ASFLAGS)
 
 # オブジェクトファイルのリストを変数にまとめる
-OBJS = $(BUILD_DIR)/ms.o \
+OBJS = $(BUILD_DIR)/main.o $(BUILD_DIR)/ms.o \
 		$(BUILD_DIR)/ms_R800_mac_30.o \
 		$(BUILD_DIR)/ms_R800_flag.o \
 		$(BUILD_DIR)/ms_iomap.o \
@@ -79,7 +79,7 @@ OBJS = $(BUILD_DIR)/ms.o \
 		$(BUILD_DIR)/ms_disk_controller_TC8566AF.o \
 		$(BUILD_DIR)/ms_disk_bios_Panasonic.o
 
-OBJS_DEBUG = $(BUILD_DIR)/ms_d.o \
+OBJS_DEBUG = $(BUILD_DIR)/main_d.o $(BUILD_DIR)/ms_d.o \
 		$(BUILD_DIR)/ms_R800_mac_30_d.o \
 		$(BUILD_DIR)/ms_R800_flag_d.o \
 		$(BUILD_DIR)/ms_iomap_d.o \
@@ -179,6 +179,12 @@ ${BUILD_DIR}/%_d.o: $(SRC_DIR)/%.has $(SRC_DIR)/ms.mac
 	$(AS) $(ASFLAGS_DEBUG) $< -o $@.tmp
 	x68k2elf.py $@.tmp $@
 	rm $@.tmp
+
+${BUILD_DIR}/main.o: $(SRC_DIR)/main.c $(SRC_DIR)/ms.h
+	$(CC) $(CFLAGS) -m68000 $< -o $@
+
+${BUILD_DIR}/main_d.o: $(SRC_DIR)/main.c $(SRC_DIR)/ms.h
+	$(CC) $(CFLAGS_DEBUG) -m68000 $< -o $@
 
 
 # VDP files

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,33 @@
+// MSX.Simulator [[ MS ]]
+//   [[ bootstrap ]]
+//
+// Copyright (C)2024 TcbnErik
+// License: MIT
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <x68k/iocs.h>
+#include "ms.h"
+
+#if defined(__mc68020__) || defined(__mc68030__) || defined(__mc68040__) || defined(__mc68060__)
+#error "please compile this file with `-m68000` option."
+#endif
+
+// IOCS work
+#define MPUTYPE ((unsigned char*)0xcbc)
+
+// ms.c
+extern int msx_main(int argc, char* argv[]);
+
+int main(int argc, char* argv[]) {
+	printf("[[ MSX Simulator MS.X %s]]\n", MS_dot_X_VERSION);
+
+	unsigned int mpu_type = (unsigned int)_iocs_b_bpeek(MPUTYPE);
+	if (mpu_type < 3) {
+		printf("MS.X ‚Ì“®ì‚É‚Í68030ˆÈã‚ª•K—v‚Å‚·\n");
+		return EXIT_FAILURE;
+	}
+
+	return msx_main(argc, argv);
+}
+

--- a/src/ms.c
+++ b/src/ms.c
@@ -192,7 +192,7 @@ char* separate_rom_kind(char* path, int* kind) {
 			xx: 10の位 = スロット番号, 1の位 = ページ番号
 			例：-r11 GAME1.ROM	: スロット1-ページ1にGAME1.ROMをセット				
 */
-int main(int argc, char *argv[]) {
+int msx_main(int argc, char *argv[]) {
 #ifdef DEBUG
 	debug_log_level = MS_LOG_DEBUG;
 #else 
@@ -230,14 +230,6 @@ int main(int argc, char *argv[]) {
 	};
 	const struct option* longopt;
 	int longindex = 0;
-
-	printf("[[ MSX Simulator MS.X %s]]\n", MS_dot_X_VERSION);
-
-	unsigned int mpu_type = _iocs_mpu_stat();
-	if( (mpu_type & 0xf) < 3) {
-		printf("MS.X の動作には 68030以上が必要です\n");
-		ms_exit();
-	}
 
 	// デフォルトの初期化
 	default_param.buf = NULL;


### PR DESCRIPTION
ms.xではMPUが68030未満の場合はエラー終了していますが、以下のことに気が付きました。

* `IOCS _SYS_STAT`はX68030で追加されたファンクションコールのため、X68000のIOCS ROMにはありません。
そのためX68000で実行するとエラー($01AC)の白帯が発生します。

* XEiJのROM1.6ではX68000モードでも`_SYS_STAT`が使用できるため白帯にはなりませんが、エラー表示後に`ms_exit()`が呼ばれ画面が初期化されるためエラー文字列が読めません。

* コンパイル時にgccに`-m68030`オプションを指定すると、MPUチェックとエラー処理のコードに68030用の命令が出力されてしまう恐れがあります。

そこで、MPU判別はIOCSのワークエリアを直接参照するようにしました。

また、該当コードをmain.cとして別ファイルに作成し、Makefileで`$(CFLAGS) -m68000`とすることで全体のオプション指定によらず必ず68000用のコードを出力させるようにしました。
